### PR TITLE
fix dependency to vgpu

### DIFF
--- a/examples/compute1/compute.go
+++ b/examples/compute1/compute.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 func init() {

--- a/examples/drawidx/drawidx.go
+++ b/examples/drawidx/drawidx.go
@@ -14,8 +14,8 @@ import (
 	vk "github.com/goki/vulkan"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"goki.dev/vgpu/v2"
 )
 
 func init() {

--- a/examples/drawtri/drawtri.go
+++ b/examples/drawtri/drawtri.go
@@ -12,8 +12,8 @@ import (
 
 	vk "github.com/goki/vulkan"
 
-	"cogentcore.org/core/vgpu"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"goki.dev/vgpu/v2"
 )
 
 func init() {

--- a/examples/exptest/exptest.go
+++ b/examples/exptest/exptest.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 func init() {

--- a/examples/memtest/memtest.go
+++ b/examples/memtest/memtest.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 func init() {

--- a/examples/phong/phong.go
+++ b/examples/phong/phong.go
@@ -19,10 +19,10 @@ import (
 	"cogentcore.org/core/math32"
 	vk "github.com/goki/vulkan"
 
-	"cogentcore.org/core/vgpu"
-	"cogentcore.org/core/vgpu/vphong"
-	"cogentcore.org/core/vgpu/vshape"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"goki.dev/vgpu/v2"
+	"goki.dev/vgpu/v2/vphong"
+	"goki.dev/vgpu/v2/vshape"
 )
 
 func init() {

--- a/examples/renderframe/renderframe.go
+++ b/examples/renderframe/renderframe.go
@@ -20,9 +20,9 @@ import (
 	"cogentcore.org/core/math32"
 	vk "github.com/goki/vulkan"
 
-	"cogentcore.org/core/vgpu"
-	"cogentcore.org/core/vgpu/vdraw"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"goki.dev/vgpu/v2"
+	"goki.dev/vgpu/v2/vdraw"
 )
 
 type CamView struct {

--- a/examples/texture/texture.go
+++ b/examples/texture/texture.go
@@ -19,8 +19,8 @@ import (
 	vk "github.com/goki/vulkan"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"goki.dev/vgpu/v2"
 )
 
 func init() {

--- a/examples/vdraw/vdraw.go
+++ b/examples/vdraw/vdraw.go
@@ -20,9 +20,9 @@ import (
 
 	vk "github.com/goki/vulkan"
 
-	"cogentcore.org/core/vgpu"
-	"cogentcore.org/core/vgpu/vdraw"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"goki.dev/vgpu/v2"
+	"goki.dev/vgpu/v2/vdraw"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.5
 
 require (
-	cogentcore.org/core v0.3.3-0.20240831051617-88df75477149
+	cogentcore.org/core v0.3.12-0.20250626010039-04e294883b0a
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a
 	github.com/goki/vulkan v1.0.8
 	github.com/stretchr/testify v1.9.0
@@ -20,7 +20,7 @@ require (
 	github.com/anthonynsimon/bild v0.13.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/chewxy/math32 v1.10.1 // indirect
-	github.com/cogentcore/webgpu v0.0.0-20240812054109-ca2e8adebe15 // indirect
+	github.com/cogentcore/webgpu v0.23.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-cogentcore.org/core v0.3.3-0.20240831051617-88df75477149 h1:gJMniGOeRjf2hnO7PfOwyCnKbSlfVa0HnnRdE8EzE0E=
-cogentcore.org/core v0.3.3-0.20240831051617-88df75477149/go.mod h1:dg3uRsPcd8S1ZYvRD2TztCtjopRkrB5V/lbl54xsQd4=
+cogentcore.org/core v0.3.12-0.20250626010039-04e294883b0a h1:Uw4+PoEMfed2EPLpYOo6Ib2inpJgPFdsXzgk+5CHdG8=
+cogentcore.org/core v0.3.12-0.20250626010039-04e294883b0a/go.mod h1:A82XMVcq3XOiG9TpT+rt7/iYD5Eu87bxxmTk8O7F4cM=
 github.com/Bios-Marcel/wastebasket v0.0.4-0.20240213135800-f26f1ae0a7c4 h1:6lx9xzJAhdjq0LvVfbITeC3IH9Fzvo1aBahyPu2FuG8=
 github.com/Bios-Marcel/wastebasket v0.0.4-0.20240213135800-f26f1ae0a7c4/go.mod h1:FChzXi1izqzdPb6BiNZmcZLGyTYiT61iGx9Rxx9GNeI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -12,8 +12,7 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/chewxy/math32 v1.10.1 h1:LFpeY0SLJXeaiej/eIp2L40VYfscTvKh/FSEZ68uMkU=
 github.com/chewxy/math32 v1.10.1/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
-github.com/cogentcore/webgpu v0.0.0-20240812054109-ca2e8adebe15 h1:Yg1VobUl2PWHzNsNVm5ong4u/zWDkucgwLvv7/qf1PU=
-github.com/cogentcore/webgpu v0.0.0-20240812054109-ca2e8adebe15/go.mod h1:ciqaxChrmRRMU1SnI5OE12Cn3QWvOKO+e5nSy+N9S1o=
+github.com/cogentcore/webgpu v0.23.0/go.mod h1:ciqaxChrmRRMU1SnI5OE12Cn3QWvOKO+e5nSy+N9S1o=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/gosl/README.md
+++ b/gosl/README.md
@@ -17,7 +17,7 @@ $ go install golang.org/x/tools/cmd/goimports@latest
 
 To install the `gosl` command, do:
 ```bash
-$ go install cogentcore.org/core/vgpu/gosl@latest
+$ go install goki.dev/vgpu/v2/gosl@latest
 ```
 
 In your Go code, use these comment directives:

--- a/gosl/examples/basic/main.go
+++ b/gosl/examples/basic/main.go
@@ -14,7 +14,7 @@ import (
 
 	"cogentcore.org/core/base/timer"
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 // note: standard one to use is plain "gosl" which should be go install'd

--- a/gosl/examples/rand/main.go
+++ b/gosl/examples/rand/main.go
@@ -13,8 +13,8 @@ import (
 
 	"cogentcore.org/core/base/timer"
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
-	"cogentcore.org/core/vgpu/gosl/sltype"
+	"goki.dev/vgpu/v2"
+	"goki.dev/vgpu/v2/gosl/sltype"
 )
 
 // note: standard one to use is plain "gosl" which should be go install'd

--- a/gosl/examples/rand/rand.go
+++ b/gosl/examples/rand/rand.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu/gosl/slrand"
-	"cogentcore.org/core/vgpu/gosl/sltype"
+	"goki.dev/vgpu/v2/gosl/slrand"
+	"goki.dev/vgpu/v2/gosl/sltype"
 )
 
 //gosl:hlsl rand

--- a/gosl/extract.go
+++ b/gosl/extract.go
@@ -104,9 +104,9 @@ func ExtractGoFiles(files []string) map[string][]byte {
 		olns = append(olns, []byte("package main"))
 		olns = append(olns, []byte(`import (
 	"math"
-	"cogentcore.org/core/vgpu/gosl/slbool"
-	"cogentcore.org/core/vgpu/gosl/slrand"
-	"cogentcore.org/core/vgpu/gosl/sltype"
+	"goki.dev/vgpu/v2/gosl/slbool"
+	"goki.dev/vgpu/v2/gosl/slrand"
+	"goki.dev/vgpu/v2/gosl/sltype"
 )
 `))
 		olns = append(olns, lns...)

--- a/gosl/files.go
+++ b/gosl/files.go
@@ -140,7 +140,7 @@ func CopySlrand() error {
 	hdr := "slrand.hlsl"
 	tofn := filepath.Join(*outDir, hdr)
 
-	pnm := "cogentcore.org/core/vgpu/gosl/slrand"
+	pnm := "goki.dev/vgpu/v2/gosl/slrand"
 
 	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName | packages.NeedFiles}, pnm)
 	if err != nil {

--- a/gosl/gosl.go
+++ b/gosl/gosl.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	"cogentcore.org/core/vgpu/gosl/slprint"
+	"goki.dev/vgpu/v2/gosl/slprint"
 )
 
 // flags

--- a/gosl/process.go
+++ b/gosl/process.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"cogentcore.org/core/vgpu/gosl/alignsl"
-	"cogentcore.org/core/vgpu/gosl/slprint"
+	"goki.dev/vgpu/v2/gosl/alignsl"
+	"goki.dev/vgpu/v2/gosl/slprint"
 	"golang.org/x/tools/go/packages"
 )
 

--- a/gosl/slbool/slboolcore/slboolcore.go
+++ b/gosl/slbool/slboolcore/slboolcore.go
@@ -6,7 +6,7 @@ package slboolcore
 
 import (
 	"cogentcore.org/core/core"
-	"cogentcore.org/core/vgpu/gosl/slbool"
+	"goki.dev/vgpu/v2/gosl/slbool"
 )
 
 func init() {

--- a/gosl/slrand/slrand.go
+++ b/gosl/slrand/slrand.go
@@ -8,7 +8,7 @@ import (
 	"math"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu/gosl/sltype"
+	"goki.dev/vgpu/v2/gosl/sltype"
 )
 
 // These are Go versions of the same Philox2x32 based random number generator

--- a/gosl/slrand/slrand_test.go
+++ b/gosl/slrand/slrand_test.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"testing"
 
-	"cogentcore.org/core/vgpu/gosl/sltype"
+	"goki.dev/vgpu/v2/gosl/sltype"
 )
 
 // Known Answer Test for values from the DEShawREsearch reference impl

--- a/gosl/testdata/basic.go
+++ b/gosl/testdata/basic.go
@@ -4,7 +4,7 @@ import (
 	"math"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu/gosl/slbool"
+	"goki.dev/vgpu/v2/gosl/slbool"
 )
 
 //gosl:endhlsl basic

--- a/gpu.go
+++ b/gpu.go
@@ -22,8 +22,8 @@ import (
 	"log/slog"
 
 	"cogentcore.org/core/base/reflectx"
-	"cogentcore.org/core/vgpu/vkinit"
 	vk "github.com/goki/vulkan"
+	"goki.dev/vgpu/v2/vkinit"
 )
 
 // Key docs: https://gpuopen.com/learn/understanding-vulkan-objects/

--- a/vals.go
+++ b/vals.go
@@ -12,8 +12,8 @@ import (
 
 	"cogentcore.org/core/enums"
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu/szalloc"
 	vk "github.com/goki/vulkan"
+	"goki.dev/vgpu/v2/szalloc"
 )
 
 // Value represents a specific value of a Var variable.

--- a/vars.go
+++ b/vars.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"cogentcore.org/core/base/indent"
-	"cogentcore.org/core/vgpu/szalloc"
+	"goki.dev/vgpu/v2/szalloc"
 
 	vk "github.com/goki/vulkan"
 )

--- a/varset.go
+++ b/varset.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"unsafe"
 
-	"cogentcore.org/core/vgpu/szalloc"
 	vk "github.com/goki/vulkan"
+	"goki.dev/vgpu/v2/szalloc"
 )
 
 // maxPerStageDescriptorSamplers is only 16 on mac -- this is the relevant limit on textures!

--- a/vdraw/config.go
+++ b/vdraw/config.go
@@ -11,8 +11,8 @@ import (
 	"unsafe"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
 	vk "github.com/goki/vulkan"
+	"goki.dev/vgpu/v2"
 )
 
 //go:embed shaders/*.spv

--- a/vdraw/draw.go
+++ b/vdraw/draw.go
@@ -12,8 +12,8 @@ import (
 	"unsafe"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
 	vk "github.com/goki/vulkan"
+	"goki.dev/vgpu/v2"
 )
 
 // These draw.Op constants are provided so that users of this package don't

--- a/vdraw/fill.go
+++ b/vdraw/fill.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 // FillRect fills given color to render target, to given region.

--- a/vdraw/vdraw.go
+++ b/vdraw/vdraw.go
@@ -10,7 +10,7 @@ import (
 	"image"
 	"sync"
 
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 // Drawer is the vDraw implementation, which draws Textures

--- a/vphong/mesh.go
+++ b/vphong/mesh.go
@@ -9,7 +9,7 @@ import (
 	"log"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 // Mesh records the number of elements in an indexed triangle mesh,

--- a/vphong/system.go
+++ b/vphong/system.go
@@ -9,8 +9,8 @@ import (
 	"unsafe"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
 	vk "github.com/goki/vulkan"
+	"goki.dev/vgpu/v2"
 )
 
 //go:embed shaders/*.spv

--- a/vphong/texture.go
+++ b/vphong/texture.go
@@ -11,7 +11,7 @@ import (
 	"log/slog"
 
 	"cogentcore.org/core/math32"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 // Texture has texture image -- stored as image.RGBA for GPU compatibility

--- a/vphong/vphong.go
+++ b/vphong/vphong.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	"cogentcore.org/core/base/ordmap"
-	"cogentcore.org/core/vgpu"
+	"goki.dev/vgpu/v2"
 )
 
 // MaxLights is upper limit on number of any given type of light


### PR DESCRIPTION
There is no `vgpu` in the Cogent Core repository (`cogentcore.org/core`) anymore, so the dependency must be updated to `goki.dev/vgpu/v2`, which is an alias for `github.com/goki/vgpu`, the dedicated repository for `vgpu`.